### PR TITLE
Add msmtpd variables and update fail2ban to 1.1.0

### DIFF
--- a/group_vars/f2b.yaml
+++ b/group_vars/f2b.yaml
@@ -1,8 +1,24 @@
 # ansible_path/group_vars/f2b.yaml
 
+# Docker service msmtpd (mail relay sidecar for Fail2ban)
+dockerServiceMsmtpdContainerName: 'msmtpd-{{ inventory_hostname }}'
+dockerServiceMsmtpdImage: 'crazymax/msmtpd:latest'
+dockerServiceMsmtpdEnvVars:
+  {
+    TZ: 'Europe/Paris',
+    SMTP_HOST: 'mail.infomaniak.com',
+    SMTP_PORT: '587',
+    SMTP_TLS: 'on',
+    SMTP_STARTTLS: 'on',
+    SMTP_AUTH: 'on',
+    SMTP_USER: '{{ eximAccountEmail }}',
+    SMTP_PASSWORD: '{{ eximAccountPassword }}',
+    SMTP_DOMAIN: '{{ serverHostname }}.lgdweb.ovh'
+  }
+
 # Docker service Fail2ban
 dockerServiceFail2banContainerName: 'fail2ban-{{ inventory_hostname }}'
-dockerServiceFail2banImage: 'crazymax/fail2ban:1.0.1'
+dockerServiceFail2banImage: 'crazymax/fail2ban:1.1.0'
 dockerServiceFail2banDestNotifEmail: '{{ vaultDockerServiceFail2banDestNotifEmail }}'
 dockerServiceFail2banCapabilities: ['NET_ADMIN', 'NET_RAW']
 dockerServiceFail2banPrivileged: true
@@ -16,12 +32,5 @@ dockerServiceFail2banEnvVars:
     F2B_LOG_LEVEL: 'INFO',
     F2B_ACTION: '%(action_mwl)s',
     F2B_DEST_EMAIL: '{{ vaultDockerServiceFail2banDestNotifEmail }}',
-    SSMTP_HOST: 'mail.infomaniak.com',
-    SSMTP_PORT: '587',
-    SSMTP_USER: '{{ eximAccountEmail }}',
-    SSMTP_PASSWORD: '{{ eximAccountPassword }}',
-    SSMTP_HOSTNAME: '{{ serverHostname }}',
-    SSMTP_TLS: 'NO',
-    SSMTP_STARTTLS: 'YES',
     F2B_IPTABLES_CHAIN: 'INPUT'
   }

--- a/playbooks/webserver/mainServices.yaml
+++ b/playbooks/webserver/mainServices.yaml
@@ -12,6 +12,17 @@
     # Create data structure for services
     - roles/dockerServices/dataStructure
 
+    # Pull msmtpd image
+    - { role: roles/docker/image, projectAppImageName: '{{ dockerServiceMsmtpdImage }}' }
+
+    # Start msmtpd docker container (mail relay for Fail2ban)
+    - {
+        role: roles/docker/container,
+        projectAppContainerName: '{{ dockerServiceMsmtpdContainerName }}',
+        projectAppImageName: '{{ dockerServiceMsmtpdImage }}',
+        projectAppEnvVars: '{{ dockerServiceMsmtpdEnvVars }}'
+      }
+
     # Pull Fail2ban image
     - { role: roles/docker/image, projectAppImageName: '{{ dockerServiceFail2banImage }}' }
 

--- a/roles/system/sshConfig/templates/sshd_config.j2
+++ b/roles/system/sshConfig/templates/sshd_config.j2
@@ -26,4 +26,4 @@ Banner /etc/issue.net
 # Cryptographic settings
 Ciphers aes256-ctr,aes192-ctr,aes128-ctr
 MACs hmac-sha2-512,hmac-sha2-256
-KexAlgorithms diffie-hellman-group-exchange-sha256
+


### PR DESCRIPTION
This pull request introduces a new Dockerized mail relay service (`msmtpd`) to work alongside Fail2ban and updates the configuration for both services. The main focus is to improve how Fail2ban sends notification emails by delegating SMTP handling to a dedicated container, and to update the Fail2ban image version. Additionally, there is a minor SSH configuration cleanup.

**Dockerized Mail Relay Integration:**

* Added configuration variables for a new `msmtpd` Docker container, including image, container name, and environment variables for SMTP relay setup in `group_vars/f2b.yaml`.
* Updated the main services playbook to pull the `msmtpd` image and start the container with the specified environment, ensuring the mail relay is available for Fail2ban notifications in `playbooks/webserver/mainServices.yaml`.

**Fail2ban Service Improvements:**

* Upgraded the Fail2ban Docker image from version `1.0.1` to `1.1.0` in `group_vars/f2b.yaml`.
* Removed direct SMTP/SSMTP environment variables from the Fail2ban container, as email sending is now handled by the `msmtpd` sidecar service in `group_vars/f2b.yaml`.

**Other Configuration:**

* Cleaned up the SSH daemon configuration template by removing a redundant `KexAlgorithms` line in `roles/system/sshConfig/templates/sshd_config.j2`.